### PR TITLE
Added support for `resume`

### DIFF
--- a/bin/workstation
+++ b/bin/workstation
@@ -261,7 +261,7 @@ case "${1:-}" in
 		rm -rf "${DATA_DIR:?}/${WORKSTATION_NAME}"
 
 		;;
-	halt|provision|rsync|status|snapshot|suspend|ssh-config|ssh)
+	halt|provision|rsync|status|snapshot|suspend|ssh-config|ssh|resume)
 		vagrant_wrapper "$@"
 
 		;;

--- a/test/vagrant_wrapping_test.bats
+++ b/test/vagrant_wrapping_test.bats
@@ -12,7 +12,7 @@ setup() {
 }
 
 @test "command reads name from file system" {
-	declare -a WRAPPED_COMMANDS=( destroy reload provision halt suspend ssh-config ssh rsync )
+	declare -a WRAPPED_COMMANDS=( destroy reload provision halt suspend resume ssh-config ssh rsync )
 
 	cat > "${scratch}/vagrant" <<'EOF'
 	#!/usr/bin/env bash
@@ -41,7 +41,7 @@ EOF
 }
 
 @test "command fails if cannot determine name from file system" {
-	declare -a WRAPPED_COMMANDS=( destroy reload provision halt suspend ssh-config ssh rsync )
+	declare -a WRAPPED_COMMANDS=( destroy reload provision halt suspend resume ssh-config ssh rsync )
 
 	cat > "${scratch}/vagrant" <<'EOF'
 	#!/usr/bin/env bash
@@ -70,7 +70,7 @@ EOF
 }
 
 @test "command WORKSTATION_NAME prefers file system based lookup" {
-	declare -a WRAPPED_COMMANDS=( destroy reload provision halt status snapshot suspend ssh-config ssh rsync)
+	declare -a WRAPPED_COMMANDS=( destroy reload provision halt status snapshot suspend resume ssh-config ssh rsync)
 
 	cat > "${scratch}/vagrant" <<'EOF'
 	#!/usr/bin/env bash
@@ -100,7 +100,7 @@ EOF
 }
 
 @test "command fails if machine does not exist" {
-	declare -a WRAPPED_COMMANDS=( destroy reload provision halt status snapshot suspend ssh-config ssh rsync )
+	declare -a WRAPPED_COMMANDS=( destroy reload provision halt status snapshot suspend resume ssh-config ssh rsync )
 
 	cat > "${scratch}/vagrant" <<'EOF'
 	#!/usr/bin/env bash
@@ -122,7 +122,7 @@ EOF
 }
 
 @test "commands are wrapped appropriately" {
-	declare -a WRAPPED_COMMANDS=( destroy reload provision halt status snapshot suspend ssh-config ssh rsync )
+	declare -a WRAPPED_COMMANDS=( destroy reload provision halt status snapshot suspend resume ssh-config ssh rsync )
 
 	cat > "${scratch}/vagrant" <<'EOF'
 	#!/usr/bin/env bash


### PR DESCRIPTION
# Added support for `$ workstation resume`
### Context

As there is support for `$ workstation suspend`, this PR adds support for `$ workstation resume`, which would resume the suspended machine.
